### PR TITLE
Revise how CUDA_VISIBLE_DEVICES propagated to qsh/qsub sessions; improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,59 +6,34 @@ Scripts to manage NVIDIA GPU devices in Grid Engine (tested with Son of Grid Eng
 Background
 ----------
 
-It is increasingly common for nodes in High-Performance Computing (HPC) clusters to be equipped with more than one GPU.
-When users submit (interactive or batch) jobs to the scheduler software that manages resources on HPC clusters, 
-the scheduler must be able to satisfy requests for 0 to $n$ GPUs, 
-where $n$ is the most GPUs available on any node in the cluster.
+It is increasingly common for nodes in High-Performance Computing (HPC) clusters to be equipped with more than one GPU.  When users submit (interactive or batch) jobs to the scheduler software that manages resources on HPC clusters, the scheduler must be able to satisfy requests for 0 to $n$ GPUs, where $n$ is the most GPUs available on any node in the cluster.  
 
-The [(Son of) Grid Engine](https://arc.liv.ac.uk/SGE/) (SoGE) scheduler 
-that we use on the University of Sheffield's [ShARC](http://docs.iceberg.shef.ac.uk/en/latest/sharc/index.html) cluster
-is very good at tracking the number of countable, consumable resources (e.g. GPUs) that are free on nodes 
-but has no in-built mechanism for assigning particular resources to particular jobs.  
-The resulting effect is that multiple users/jobs may end up using the same GPU (in a time-sliced manner) 
-even though other GPUs in the same node are unused.
+The [(Son of) Grid Engine](https://arc.liv.ac.uk/SGE/) (SoGE) scheduler that we use on the University of Sheffield's [ShARC](http://docs.iceberg.shef.ac.uk/en/latest/sharc/index.html) cluster is very good at tracking the number of countable, consumable resources (e.g. GPUs) that are free on nodes but has no in-built mechanism for assigning particular resources to particular jobs.  The resulting effect is that multiple users/jobs may end up using the same GPU (in a time-sliced manner) even though other GPUs in the same node are unused.
 
-For example, say that only one node in a cluster contains GPUs (four of them) 
-and that we define within SoGE's configuration a countable resource called `gpu` 
-then define maximum values for it per node.  
-If Alice submits a job where she requests one GPU and then Bob requests a GPU then
-the scheduler knows that two out of four GPUs have been allocated.
-However, neither user has been told _which_ to use so, potentially without realising it,
-both could use the GPU with 'index' 0 (the first using an invariant means of enumeration).
+For example, say that only one node in a cluster contains GPUs (four of them) and that we define within SoGE's configuration a countable resource called `gpu` then define maximum values for it per node.  If Alice submits a job where she requests one GPU and then Bob requests a GPU then the scheduler knows that two out of four GPUs have been allocated.  However, neither user has been told _which_ to use so, potentially without realising it, both could use the GPU with 'index' 0 (the first using an invariant means of enumeration).
 
-By probing each GPU (by index) in turn Alice and Bob could try to identify GPUs that are not busy 
-but this a horribly ad-hoc and unreliable approach.  
-What is required here is a mechanism by which Alice and Bob could be forced or instructed to use particular GPUs.
-Other schedulers have suitable in-built mechanisms for managing mappings between jobs and countable, consumable resources: 
-[SLURM](https://slurm.schedmd.com/) does, as does 
-Univa's version of Grid Engine (thanks to the [RSMAP complex](http://gridengine.eu/grid-engine-internals/102-univa-grid-engine-810-features-part-2-better-resource-management-with-the-rsmap-complex-2012-05-25))
+By probing each GPU (by index) in turn Alice and Bob could try to identify GPUs that are not busy but this a horribly ad-hoc and unreliable approach.  What is required here is a mechanism by which Alice and Bob could be forced or instructed to use particular GPUs.  Other schedulers have suitable in-built mechanisms for managing mappings between jobs and countable, consumable resources: [SLURM](https://slurm.schedmd.com/) does, as does Univa's version of Grid Engine (thanks to the [RSMAP complex](http://gridengine.eu/grid-engine-internals/102-univa-grid-engine-810-features-part-2-better-resource-management-with-the-rsmap-complex-2012-05-25))
 
 This approach
 -------------
 
-At the University of Sheffield we use these SoGE [queue **prolog** and **epilog**](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) scripts to 
-maintain a mapping between jobs and allocated NVIDIA GPUs.  This works as follows:
+At the University of Sheffield we use these SoGE [queue **prolog** and **epilog**](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) scripts to maintain a mapping between jobs and allocated NVIDIA GPUs.  This works as follows:
 
-1. A user submits a job where he/she requests between 0 and $n$ GPUs.  
-   This job is explicitly or implicitly assigned to an SoGE queue (e.g. `gpu.q`).
+1. A user submits a job where he/she requests between 0 and $n$ GPUs.  This job is explicitly or implicitly assigned to an SoGE queue (e.g. `gpu.q`).
 1. Just before the job is started on a node the queue's custom **prolog** program runs **on that node**.  This:
     1. Queries the scheduler to determine the number of GPUs requested (then exits if that is <=0)
     1. Uses the `nvidia-smi` utility to discover the indexes of *all* GPUs on the node.
     1. For all indexes (shuffled) initialise a counter to 0 then: 
-        1. Try to create a lock by using `mkdir` to create a directory containing the GPU index
-           (`mkdir` is one of the operations that [UNIX/POSIX can do atomically](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html)).
+        1. Try to create a lock by using `mkdir` to create a directory containing the GPU index (`mkdir` is one of the operations that [UNIX/POSIX can do atomically](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html)).
         1. If this suceeds append the index to a list and increment the counter.
         1. If the counter exceeds the number of GPUs requested then break out of the loop early.
-    1. If the counter is less then the number of GPUs requested then put the job in an error state 
-       (**TODO**: after releasing all locks aquired within the 'for' loop).
+    1. If the counter is less then the number of GPUs requested then put the job in an error state (**TODO**: after releasing all locks aquired within the 'for' loop).
     1. Convert the list (of assigned GPU indexes) into a comma-separated string.
     1. Writes `CUDA_VISIBLE_DEVICES=<index list>` into the `environment` file in the node-specific spool directory of the job.
 1. This file is then used to instantiate the environment of the resulting interactive (`qsh`) or batch (`qsub`) session.
-1. CUDA will then [only use GPUs whose indexes](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) 
-   are in the comma-separated list in `$CUDA_VISIBLE_DEVICES`.
+1. CUDA will then [only use GPUs whose indexes](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) are in the comma-separated list in `$CUDA_VISIBLE_DEVICES`.
 
-When the job finishes, the complementary **epilog** script iterates over the indexes in the `$CUDA_VISIBLE_DEVICES` list 
-and removes all the corresponding lock directories, allowing the corresponding GPUs to be used by queued/future jobs.
+When the job finishes, the complementary **epilog** script iterates over the indexes in the `$CUDA_VISIBLE_DEVICES` list and removes all the corresponding lock directories, allowing the corresponding GPUs to be used by queued/future jobs.
 
 This approach is based on [https://github.com/kyamagu/sge-gpuprolog](https://github.com/kyamagu/sge-gpuprolog).
 
@@ -67,6 +42,9 @@ Limitations
 
  * No mechanism to enable **over-subscription** (the sharing of a GPU resource between jobs).
  * GPUs tied to a job for the job's entire duration, which may or may not be an efficient use of resources depending on the workload.
+ * Locks may need to be manually removed if anything goes wrong but
+    * Writing them to a temporary filesystem ([`tmpfs`](https://en.wikipedia.org/wiki/Tmpfs)) will ensure locks do not persist across reboots.
+    * There are mechanisms (e.g. [`systemd-tmpfiles`](https://www.freedesktop.org/software/systemd/man/systemd-tmpfiles.html)) that allow locks older than the maximum SoGE job run time to be automatically removed.
 
 Compatible versions
 -------------------
@@ -118,17 +96,10 @@ The `sge@` is important: it means that the prolog and epilog scripts will be run
 Usage
 -----
 
-Request a `gpu` resource when you submit your job 
-(explicitly selecting a queue that uses these prolog and epilog scripts 
-if an appropriate queue is not automatically selected 
-by the scheduler by the user simply requesting a `gpu` resource).
+Request a `gpu` resource when you submit your job (explicitly selecting a queue that uses these prolog and epilog scripts if an appropriate queue is not automatically selected by the scheduler by the user simply requesting a `gpu` resource).
 
 ```
 qsub -q gpu.q -l gpu=1 gpujob.sh
 ```
 
-The `CUDA_VISIBLE_DEVICES` environment variable should then be defined in the environment of the job, 
-which contains a comma-delimited string of device indexes, such as `0` or `0,1,2`.
-CUDA will then use to identify the subset of devices to be used.
-
-for `cudaSetDevice()`.
+The `CUDA_VISIBLE_DEVICES` environment variable should then be defined in the environment of the job, which contains a comma-delimited string of device indexes, such as `0` or `0,1,2`.  CUDA will then use to identify the subset of devices to be used.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Gridengine GPU prolog
-=====================
+Grid Engine + GPU prolog and epilog scripts
+===========================================
 
-Scripts to manage NVIDIA GPU devices in SGE 6.2u5.
+Scripts to manage NVIDIA GPU devices in Grid Engine (tested with Son of Grid Engine 8.1.9).
 
-The last Sun Grid Engine that is packaged in Ubuntu 14.04 LTS does not contain
-the RSMAP functionality that is implemented in recent Univa Grid Engine. The
-ad-hoc scripts in this package implement resource allocation for NVIDIA devices.
+Son of Grid Engine 8.1.9 and earlier do not feature the 
+RSMAP functionality that is implemented in recent Univa Grid Engine. 
+The ad-hoc scripts in this package implement resource allocation for NVIDIA devices.
 
 
 Installation
@@ -19,16 +19,19 @@ First, set up consumable complex `gpu`.
     #----------------------------------------------------------------------------------------------
     gpu                 gpu        INT         <=      YES         YES        0        0
 
-At each exec-host, add `gpu` resource complex. For example,
 
-    qconf -aattr exechost complex_values gpu=1 node01
+At each exec-host, add the `gpu` resource complex. For example:
 
-Set up `prolog` and `epilog` in the queue.
+    qconf -aattr exechost complex_values gpu=1 node001
+
+Set up `prolog` and `epilog` scripts for the relevant queue(s):
 
     qconf -mq gpu.q
 
-    prolog                sgeadmin@/path/to/sge-gpuprolog/prolog.sh
-    epilog                sgeadmin@/path/to/sge-gpuprolog/epilog.sh
+    prolog                sge@/path/to/sge-gpuprolog/prolog.sh
+    epilog                sge@/path/to/sge-gpuprolog/epilog.sh
+
+Note that the `sge@` prefix means that the prolog and epilog scripts will be run as the `sge` user, not as the end-user.
 
 Alternatively, you may set up a parallel environment for GPU and set
 `start_proc_args` and `stop_proc_args` to the packaged scripts.
@@ -40,10 +43,10 @@ Request `gpu` resource in the designated queue.
 
     qsub -q gpu.q -l gpu=1 gpujob.sh
 
-The job script can access `SGE_GPU` variable.
+The job script can access `CUDA_VISIBLE_DEVICES` variable.
 
     #!/bin/sh
-    echo $SGE_GPU
+    echo $CUDA_VISIBLE_DEVICES
 
 The variable contains a comma-delimited device IDs, such as `0` or `0,1,2`
 depending on the number of `gpu` resources to be requested. Use the device ID

--- a/README.md
+++ b/README.md
@@ -3,51 +3,132 @@ Grid Engine + GPU prolog and epilog scripts
 
 Scripts to manage NVIDIA GPU devices in Grid Engine (tested with Son of Grid Engine 8.1.9).
 
-Son of Grid Engine 8.1.9 and earlier do not feature the 
-RSMAP functionality that is implemented in recent Univa Grid Engine. 
-The ad-hoc scripts in this package implement resource allocation for NVIDIA devices.
+Background
+----------
 
+It is increasingly common for nodes in High-Performance Computing (HPC) clusters to be equipped with more than one GPU.
+When users submit (interactive or batch) jobs to the scheduler software that manages resources on HPC clusters, 
+the scheduler must be able to satisfy requests for 0 to $n$ GPUs, 
+where $n$ is the most GPUs available on any node in the cluster.
+
+The [(Son of) Grid Engine](https://arc.liv.ac.uk/SGE/) (SoGE) scheduler 
+that we use on the University of Sheffield's [ShARC](http://docs.iceberg.shef.ac.uk/en/latest/sharc/index.html) cluster
+is very good at tracking the number of countable, consumable resources (e.g. GPUs) that are free on nodes 
+but has no in-built mechanism for assigning particular resources to particular jobs.  
+The resulting effect is that multiple users/jobs may end up using the same GPU (in a time-sliced manner) 
+even though other GPUs in the same node are unused.
+
+For example, say that only one node in a cluster contains GPUs (four of them) 
+and that we define within SoGE's configuration a countable resource called `gpu` 
+then define maximum values for it per node.  
+If Alice submits a job where she requests one GPU and then Bob requests a GPU then
+the scheduler knows that two out of four GPUs have been allocated.
+However, neither user has been told _which_ to use so, potentially without realising it,
+both could use the GPU with 'index' 0 (the first using an invariant means of enumeration).
+
+By probing each GPU (by index) in turn Alice and Bob could try to identify GPUs that are not busy 
+but this a horribly ad-hoc and unreliable approach.  
+What is required here is a mechanism by which Alice and Bob could be forced or instructed to use particular GPUs.
+Other schedulers have suitable in-built mechanisms for managing mappings between jobs and countable, consumable resources: 
+[SLURM](https://slurm.schedmd.com/) does, as does 
+Univa's version of Grid Engine (thanks to the [RSMAP complex](http://gridengine.eu/grid-engine-internals/102-univa-grid-engine-810-features-part-2-better-resource-management-with-the-rsmap-complex-2012-05-25))
+
+This approach
+-------------
+
+At the University of Sheffield we use these SoGE [queue **prolog** and **epilog**](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) scripts to 
+maintain a mapping between jobs and allocated NVIDIA GPUs.  This works as follows:
+
+1. A user submits a job where he/she requests between 0 and $n$ GPUs.  
+   This job is explicitly or implicitly assigned to an SoGE queue (e.g. `gpu.q`).
+1. Just before the job is started on a node the queue's custom **prolog** program runs **on that node**.  This:
+    1. Queries the scheduler to determine the number of GPUs requested (then exits if that is <=0)
+    1. Uses the `nvidia-smi` utility to discover the indexes of *all* GPUs on the node.
+    1. For all indexes (shuffled) initialise a counter to 0 then: 
+        1. Try to create a lock by using `mkdir` to create a directory containing the GPU index
+           (`mkdir` is one of the operations that [UNIX/POSIX can do atomically](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html)).
+        1. If this suceeds append the index to a list and increment the counter.
+        1. If the counter exceeds the number of GPUs requested then break out of the loop early.
+    1. If the counter is less then the number of GPUs requested then put the job in an error state 
+       (**TODO**: after releasing all locks aquired within the 'for' loop).
+    1. Convert the list (of assigned GPU indexes) into a comma-separated string.
+    1. Writes `CUDA_VISIBLE_DEVICES=<index list>` into the `environment` file in the node-specific spool directory of the job.
+1. This file is then used to instantiate the environment of the resulting interactive (`qsh`) or batch (`qsub`) session.
+1. CUDA will then [only use GPUs whose indexes](http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml) 
+   are in the comma-separated list in `$CUDA_VISIBLE_DEVICES`.
+
+When the job finishes, the complementary **epilog** script iterates over the indexes in the `$CUDA_VISIBLE_DEVICES` list 
+and removes all the corresponding lock directories, allowing the corresponding GPUs to be used by queued/future jobs.
+
+This approach is based on [https://github.com/kyamagu/sge-gpuprolog](https://github.com/kyamagu/sge-gpuprolog).
+
+Limitations
+-----------
+
+ * No mechanism to enable **over-subscription** (the sharing of a GPU resource between jobs).
+ * GPUs tied to a job for the job's entire duration, which may or may not be an efficient use of resources depending on the workload.
+
+Compatible versions
+-------------------
+
+Tested with Son of Grid Engine 8.1.9 but will most likely work with other versions.
 
 Installation
 ------------
 
-First, set up consumable complex `gpu`.
+First, set up a consumable complex `gpu`:
 
-    qconf -mc
+```
+$ qconf -mc
+```
 
-    #name               shortcut   type        relop   requestable consumable default  urgency
-    #----------------------------------------------------------------------------------------------
-    gpu                 gpu        INT         <=      YES         YES        0        0
+then within an editor:
+
+```
+#name               shortcut   type        relop   requestable consumable default  urgency
+#----------------------------------------------------------------------------------------------
+gpu                 gpu        INT         <=      YES         YES        0        0
+```
 
 
-At each exec-host, add the `gpu` resource complex. For example:
+Add the `gpu` resource complex on each execution host in the cluster, specifying the number of GPUs available. For example:
 
-    qconf -aattr exechost complex_values gpu=1 node001
+```
+$ qconf -aattr exechost complex_values gpu=1 node001
+```
 
-Set up `prolog` and `epilog` scripts for the relevant queue(s):
+Set up `prolog` and `epilog` scripts for the relevant scheduler queue(s).  For example, for the `gpu.q` queue:
 
-    qconf -mq gpu.q
+```
+$ qconf -mq gpu.q
+```
 
-    prolog                sge@/path/to/sge-gpuprolog/prolog.sh
-    epilog                sge@/path/to/sge-gpuprolog/epilog.sh
+then within an editor ensure the `prolog` and `epilog` lines read:
 
-Note that the `sge@` prefix means that the prolog and epilog scripts will be run as the `sge` user, not as the end-user.
+```
+prolog                sge@/path/to/prolog.sh
+epilog                sge@/path/to/epilog.sh
+```
 
-Alternatively, you may set up a parallel environment for GPU and set
-`start_proc_args` and `stop_proc_args` to the packaged scripts.
+The `sge@` is important: it means that the prolog and epilog scripts will be run as the `sge` user, not as the end-user, so:
+
+* the prolog script has the permissions to append to `$SGE_JOB_SPOOL_DIR/environment` and
+* the epilog script has the permissions to remove the lock directories created by the prolog script.
 
 Usage
 -----
 
-Request `gpu` resource in the designated queue.
+Request a `gpu` resource when you submit your job 
+(explicitly selecting a queue that uses these prolog and epilog scripts 
+if an appropriate queue is not automatically selected 
+by the scheduler by the user simply requesting a `gpu` resource).
 
-    qsub -q gpu.q -l gpu=1 gpujob.sh
+```
+qsub -q gpu.q -l gpu=1 gpujob.sh
+```
 
-The job script can access `CUDA_VISIBLE_DEVICES` variable.
+The `CUDA_VISIBLE_DEVICES` environment variable should then be defined in the environment of the job, 
+which contains a comma-delimited string of device indexes, such as `0` or `0,1,2`.
+CUDA will then use to identify the subset of devices to be used.
 
-    #!/bin/sh
-    echo $CUDA_VISIBLE_DEVICES
-
-The variable contains a comma-delimited device IDs, such as `0` or `0,1,2`
-depending on the number of `gpu` resources to be requested. Use the device ID
 for `cudaSetDevice()`.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ The `sge@` is important: it means that the prolog and epilog scripts will be run
 * the prolog script has the permissions to append to `$SGE_JOB_SPOOL_DIR/environment` and
 * the epilog script has the permissions to remove the lock directories created by the prolog script.
 
+Finally, ensure that the directory that will contain the lock files is present on all nodes.  This needs to be readable and writable by the `sge` user.  The prolog and epilog scripts learn of this path via the `SGE_GPU_LOCKS_DIR` environment variable.  On the University of Sheffield's ShARC cluster this is set in `/etc/profile.d/SoGE.sh` on all nodes.
+
+To ensure that locks are cleared after reboots and after a set duration (just longer than the longest possible job; 4 days at the time of writing) the `$SGE_GPU_LOCKS_DIR` is created with appropriate permissions at boot time by the [systemd-tmpfiles](https://www.freedesktop.org/software/systemd/man/systemd-tmpfiles.html) mechanism.  This is set up on all nodes using:
+
+    echo 'D /tmp/sge-gpu 0755 sge users 5d' > /etc/tmpfiles.d/sge-gpu.conf 
+    systemctl enable systemd-tmpfiles-setup.service
+    systemctl enable systemd-tmpfiles-clean.timer
+
 Usage
 -----
 

--- a/epilog.sh
+++ b/epilog.sh
@@ -12,7 +12,7 @@ device_ids="$(echo $CUDA_VISIBLE_DEVICES | sed -e "s/,/ /g")"
 
 # Loop through through the device IDs and free the lockfile
 for device_id in $device_ids; do
-  # Lock file is specific for each ShARC node and each device combination (node_number is a SGE prolog variable)
+  # Lock file is specific for each ShARC node and each device combination
   lockfile="/tmp/sge-gpu/lock_device_${device_id}"
 
   # Check dir exists then remove the lockfile

--- a/epilog.sh
+++ b/epilog.sh
@@ -1,25 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 #
-# Authors: Mozhgan Kabiri Chimeh, Paul Richmond
+# Authors: Mozhgan Kabiri Chimeh, Paul Richmond, Will Furnass
 # Contact: m.kabiri-chimeh@sheffield.ac.uk
 #
-# Epilog script to free GPU lock files for devices used by a job.
+# Sun Grid Engine Epilog script to free GPU lock files for devices used by a job.
 # Based on https://github.com/kyamagu/sge-gpuprolog
 #
 
 # Reformat the list of device ids used by the job (into space seperated)
-device_ids=$(echo $CUDA_VISIBLE_DEVICES | sed -e "s/,/ /g")
+device_ids="$(echo $CUDA_VISIBLE_DEVICES | sed -e "s/,/ /g")"
 
 # Loop through through the device IDs and free the lockfile
-for device_id in $device_ids
-do
-  #lock file is specific for each ShARC node and each device combination (node_number is a SGE prolog variable)
-  lockfile=/tmp/lock_$node_number"_device"$device_id
+for device_id in $device_ids; do
+  # Lock file is specific for each ShARC node and each device combination (node_number is a SGE prolog variable)
+  lockfile="/tmp/sge-gpu/lock_device_${device_id}"
+
   # Check dir exists then remove the lockfile
-  if [ -d $lockfile ]
-  then
+  if [[ -d $lockfile ]]; then
     rmdir $lockfile
-    echo "removed lock from $lockfile"
   fi
 done
 #exit 0

--- a/epilog.sh
+++ b/epilog.sh
@@ -13,7 +13,7 @@ device_ids="$(echo $CUDA_VISIBLE_DEVICES | sed -e "s/,/ /g")"
 # Loop through through the device IDs and free the lockfile
 for device_id in $device_ids; do
   # Lock file is specific for each ShARC node and each device combination
-  lockfile="/tmp/sge-gpu/lock_device_${device_id}"
+  lockfile="${SGE_GPU_LOCKS_DIR}/lock_device_${device_id}"
 
   # Check dir exists then remove the lockfile
   if [[ -d $lockfile ]]; then

--- a/prolog.sh
+++ b/prolog.sh
@@ -22,11 +22,13 @@ SGE_GPU=""
 # Counter for free devices that we have obtained a lock on
 i=0
 # Get a list of all device IDS which will be space seperated
+#   NB 'nvidia-smi -L' returns lines like
+#   GPU 0: Tesla P100-SXM2-16GB (UUID: GPU-e0fd54a5-16ce-5f57-b5c4-0ecebdd5a450)
 device_ids=$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)
 
 # Loop through the device IDs and check to see if a lock can be obtained for the device
 for device_id in $device_ids; do
-  # Lock file is specific for each ShARC node and each device combination ('node_number' is a SGE prolog variable)
+  # Lock file is specific for each ShARC node and each device combination
   lockfile="/tmp/sge-gpu/lock_device_${device_id}"
 
   # Use 'mkdir' to obtain a lock (will fail if file exists)
@@ -35,7 +37,8 @@ for device_id in $device_ids; do
     SGE_GPU="$SGE_GPU $device_id"
     # Increment i counter to reflect that we have obtained a GPU for the job
     i=$(expr $i + 1)
-    if [[ $i -ge $NGPUS ]]; then # check if reserved num gpus are greater than requested number of GPUS
+    # Check if reserved num gpus are greater than requested number of GPUS
+    if [[ $i -ge $NGPUS ]]; then 
       break
     fi
   fi

--- a/prolog.sh
+++ b/prolog.sh
@@ -44,9 +44,13 @@ for device_id in $device_ids; do
   fi
 done
 
-# Check if reserved num GPUs are less than requested number of GPUS. 
+# If running this script as part of stand-alone tests (without Grid Engine) then
+# check if fewer GPUs were reserved than requested.
 # If this is true then there were not enough free devices for the job 
-# and the scheduling should fail
+# and the (dummy) scheduling should fail.
+# This logic is not needed if running this script as a Grid Engine prolog script 
+# as by the time this runs the scheduler has already checked 
+# that there are a sufficient number of free GPUs to satisfy the request.
 if [[ $i -lt $NGPUS ]]; then
   echo "ERROR: Only reserved $i of $NGPUS requested devices."
   exit 100

--- a/prolog.sh
+++ b/prolog.sh
@@ -1,25 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 #
-# Authors: Mozhgan Kabiri Chimeh, Paul Richmond
+# Authors: Mozhgan Kabiri Chimeh, Paul Richmond, Will Furnass
 # Contact: m.kabiri-chimeh@sheffield.ac.uk
 #
-# Startup script to allocate GPU devices.
+# Sun Grid Engine prolog script to allocate GPU devices.
 # Based on https://github.com/kyamagu/sge-gpuprolog
-#
-# IMPORTANT: You need to source this script (use . prolog.sh to run in bash). See testPrologEpilog.sh as an example.
 
-# Query how many gpus to allocate.Using qstat
-NGPUS=$(qstat -j $JOB_ID | \
-        sed -n "s/hard resource_list:.*gpu=\([[:digit:]]\+\).*/\1/p")
-if [ -z $NGPUS ] # check if NGPUS is null, then exit
-then
-  exit 0
-fi
-if [ $NGPUS -le 0 ]  # check if NGPUS are less than equal 0, then exit
-then
-  exit 0
-fi
+source /etc/profile.d/SoGE.sh
 
+# Query how many gpus to allocate (using qstat)
+NGPUS="$(qstat -j $JOB_ID | sed -n "s/hard resource_list:.*gpu=\([[:digit:]]\+\).*/\1/p")" || true
+
+# Exit if NGPUs is null
+[[ -z $NGPUS ]] && exit 0
+
+# Exit if NGPUS <= 0
+[[ $NGPUS -le 0 ]] && exit 0
 
 # Allocate and lock GPUs. We will populate SGE_GPU with the device IDs that the job should use.
 SGE_GPU=""
@@ -28,38 +24,36 @@ i=0
 # Get a list of all device IDS which will be space seperated
 device_ids=$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)
 
-#loop through the device IDs and check to see if a lock can be obtained for the device
-for device_id in $device_ids
-do
-  #lock file is specific for each ShARC node and each device combination (node_number is a SGE prolog variable)
-  lockfile=/tmp/lock_$node_number"_device"$device_id
-  #use mkdir to obtain a lock (will fail if file exists)
-  if mkdir $lockfile
-  then
+# Loop through the device IDs and check to see if a lock can be obtained for the device
+for device_id in $device_ids; do
+  # Lock file is specific for each ShARC node and each device combination ('node_number' is a SGE prolog variable)
+  lockfile="/tmp/sge-gpu/lock_device_${device_id}"
+
+  # Use 'mkdir' to obtain a lock (will fail if file exists)
+  if mkdir $lockfile; then 
     # We have obtained a lock so can have exclusive access to this GPU id. Add the ID to SGE_GPU
     SGE_GPU="$SGE_GPU $device_id"
     # Increment i counter to reflect that we have obtained a GPU for the job
     i=$(expr $i + 1)
-    if [ $i -ge $NGPUS ] # check if reserved num gpus are greater than requested number of GPUS
-    then
+    if [[ $i -ge $NGPUS ]]; then # check if reserved num gpus are greater than requested number of GPUS
       break
     fi
   fi
 done
 
- # Check if reserved num gpus are less than requested number of GPUS. If this is true then there were not enough free devices for the job and the scheduling should fail
-if [ $i -lt $NGPUS ]
-then
+# Check if reserved num GPUs are less than requested number of GPUS. 
+# If this is true then there were not enough free devices for the job 
+# and the scheduling should fail
+if [[ $i -lt $NGPUS ]]; then
   echo "ERROR: Only reserved $i of $NGPUS requested devices."
-  exit 1
+  exit 100
 fi
 
-
-# Set the cuda devices visible. This will re-enumerate the devices to users. i.e. a job requesting 1 device which locks device_id=3 will see this as device 0 in nvidia-smi
+# Set the cuda devices visible. This will re-enumerate the devices to users. 
+# i.e. a job requesting 1 device which locks device_id=3 will see this as device 0 in nvidia-smi
 SGE_GPU="$(echo $SGE_GPU | sed -e 's/^ //' | sed -e 's/ /,/g')" # seperating device_ids with comma
 
-# Set the environment.
-# IMPORTANT: You need to source this script (use source to execute it), so that the variable modified by the script will be available after the script completes
-export CUDA_VISIBLE_DEVICES=$SGE_GPU 
+# Set the environment (NB cannot just 'export' CUDA_VISIBLE_DEVICES as this script is not 'source'd)
+echo "CUDA_VISIBLE_DEVICES=$SGE_GPU" >> $SGE_JOB_SPOOL_DIR/environment
 
 #exit 0

--- a/prolog.sh
+++ b/prolog.sh
@@ -29,7 +29,7 @@ device_ids=$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)
 # Loop through the device IDs and check to see if a lock can be obtained for the device
 for device_id in $device_ids; do
   # Lock file is specific for each ShARC node and each device combination
-  lockfile="/tmp/sge-gpu/lock_device_${device_id}"
+  lockfile="${SGE_GPU_LOCKS_DIR}/lock_device_${device_id}"
 
   # Use 'mkdir' to obtain a lock (will fail if file exists)
   if mkdir $lockfile; then 

--- a/qstat
+++ b/qstat
@@ -4,18 +4,21 @@
 # Startup script to allocate GPU devices.
 # Based on https://github.com/kyamagu/sge-gpuprolog
 #
-# The script is written to emulate the 'qstat' command. It gets the number of GPUs as the JOB_ID and replaces it with the number of GPUs in 'userTest' file and echos it.
-# Note that it gets environment varible that would normally be the $JOB_ID. We use the Job ID as the number of devices that qstat should return
+# The script is written to emulate the 'qstat' command. 
+# It gets the number of GPUs as the JOB_ID and 
+# replaces it with the number of GPUs in the 'userTest' file and echos it.
+# Note that it gets environment varible that would normally be the $JOB_ID. 
+# We use the Job ID as the number of devices that qstat should return
 
 # To execute, simply run qstat -j $2, where $2 would be the number of GPUs
 
 NUM_GPUS=$2 # this is normaly the $JOB_ID, but here we are using it as the NUM_GPUS
 
-# replaces the number of gpus already existed in the Twins qstat output with the one recieved from the user
+# Replaces the number of gpus already existed in the Twins qstat output with
+# the one recieved from the user
 replace_func(){
-sed -i -e "s/gpu=[[:digit:]]/gpu=$NUM_GPUS/g" userTest
+    sed -i -e "s/gpu=[[:digit:]]/gpu=$NUM_GPUS/g" userTest
 }
-
 
 # Loop until all parameters are used up
 if [ "$2" != "" ]; then
@@ -23,8 +26,3 @@ if [ "$2" != "" ]; then
 fi
 
 cat userTest
-
-
-
-
-

--- a/testPrologEpilog.sh
+++ b/testPrologEpilog.sh
@@ -1,35 +1,53 @@
 #!/bin/bash
 #
-# Authors: Mozhgan Kabiri Chimeh, Paul Richmond
+# Authors: Mozhgan Kabiri Chimeh, Paul Richmond, Will Furnass
 # Contact: m.kabiri-chimeh@sheffield.ac.uk
 #
 # Startup script to allocate GPU devices.
 # Based on https://github.com/kyamagu/sge-gpuprolog
 #
-# The script is written to test if both Prolog and Epilog scripts are working
-# For this purpose, we created another script called 'qstat' to emulate what the real 'qstat' command does.
-# To execute, simply run ./testPriloEpilog $1 , where $1 is the number of gpus. This is actually the $JOB_ID, but we as we use a fake one, we set this as the number of GPUs user requested
+# The script is written to test if both the prolog and epilog scripts are working.
+# For this purpose, we created another script called 'qstat' to 
+# emulate what the real 'qstat' command does.
+#
+# Requires the 'deviceQuery' program included with the CUDA samples
 
+export SGE_GPU_LOCKS_DIR=/tmp/sge-gpu-test
+export SGE_JOB_SPOOL_DIR=/tmp/dummy-sge-spool-dir 
 # The system will look for executables in current directory without a "./". 
-export PATH=$PATH:. 
+export PATH=${PATH}:. 
 
+usage() {
+    echo "Usage: $0 <num-gpus> <cuda-deviceQuery-prog>" 1>&2
+    exit 1
+}
 
+# Check the command-line arguments
+[[ $# -eq 2 ]] || usage
+[[ $1 -gt 0 ]] || usage
+# Reuse $JOB_ID: set this as the number of GPUs user requested (WF: ?)
 JOB_ID=$1 # num gpus
+DEVICE_QUERY="$2"
+[[ -x $DEVICE_QUERY ]] || usage
+
+# DELETEME?
+# To execute, simply run ./testPrologEpilog.sh $1, where $1 is the number of gpus. 
+# DELETEME?
 
 # Output the directory status list for lock files
 check_locks_func() {
-  echo
-  echo "------------------------------------"
-  for device_id in $device_ids; do
-    lockfile="/tmp/sge-gpu/lock_device_$device_id"
-    if [[ -d $lockfile ]]; then 
-      echo "$lockfile exists"
-    else
-      echo "no lock exists on $lockfile"
-    fi
-  done
-  echo "------------------------------------"
-  echo
+    echo
+    echo "------------------------------------"
+    for device_id in $device_ids; do
+        lockfile="${SGE_GPU_LOCKS_DIR}/lock_device_$device_id"
+        if [[ -d $lockfile ]]; then 
+            echo "Lock file $lockfile exists"
+        else
+            echo "Lock file $lockfile does not exist"
+        fi
+    done
+    echo "------------------------------------"
+    echo
 }
 
 # Output current list of devices IDS from nvidia-smi
@@ -41,32 +59,28 @@ deviceId_func() {
 #################################################
 
 # Create directory to store lock files
-mkdir -p /tmp/sge-gpu
-find /tmp/sge-gpu/ -type d -exec rmdir {} \;
-mkdir -p /tmp/dummy-sge-spool-dir
-find /tmp/dummy-sge-spool-dir/ -type f -exec rm {} \;
+mkdir -p $SGE_GPU_LOCKS_DIR
+find $SGE_GPU_LOCKS_DIR -mindepth 1 -type d -empty -delete
 
-# Create dummy Sun Grid Engine job spool directory
-export $SGE_JOB_SPOOL_DIR=/tmp/dummy-sge-spool-dir 
+# Create dummy Sun Grid Engine job spool directory and job environment file
 mkdir -p $SGE_JOB_SPOOL_DIR
 truncate --size=0 $SGE_JOB_SPOOL_DIR/environment
 
-echo "START ...."
+echo "START ..."
 export JOB_ID=$1 # num gpus
 
 deviceId_func
 check_locks_func
 
-echo "executing Prolog ..................."
-echo "source ./prolog.sh"
+echo "Executing prolog script as a subprocess: "
 bash prolog.sh
 
-# setting NVIDIA sample path to check the number of visible devices, make sure to compile/build the deviceQuery before hand
-~/NVIDIA_CUDA-8.0_Samples/1_Utilities/deviceQuery/deviceQuery  -noprompt | egrep "^Device"
+# Display the number of visible devices
+$DEVICE_QUERY -noprompt | egrep "^Device"
 check_locks_func
 
-echo "executing Epilog ..................."
-bash ./epilog.sh
+echo "Executing epilog script"
+bash epilog.sh
 
 check_locks_func
 echo "DONE"

--- a/testPrologEpilog.sh
+++ b/testPrologEpilog.sh
@@ -15,53 +15,58 @@ export PATH=$PATH:.
 
 
 JOB_ID=$1 # num gpus
-node_number=$2 # user defined
 
 # Output the directory status list for lock files
-check_locks_func(){
-echo
-echo "------------------------------------"
-for device_id in $device_ids
-do
-  lockfile=/tmp/lock_$node_number"_device"$device_id
-  if [ -d $lockfile ]
-  then
-     echo "$lockfile exists"
-  else
-     echo "no lock exists on $lockfile"
-  fi
-done
-echo "------------------------------------"
-echo
+check_locks_func() {
+  echo
+  echo "------------------------------------"
+  for device_id in $device_ids; do
+    lockfile="/tmp/sge-gpu/lock_device_$device_id"
+    if [[ -d $lockfile ]]; then 
+      echo "$lockfile exists"
+    else
+      echo "no lock exists on $lockfile"
+    fi
+  done
+  echo "------------------------------------"
+  echo
 }
 
-# Output current list of devices IDS from NVIDIA-SMI
-deviceId_func(){
-device_ids=$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)
-echo "Current list of devices: $device_ids"
+# Output current list of devices IDS from nvidia-smi
+deviceId_func() {
+  device_ids="$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)"
+  echo "Current list of devices: $device_ids"
 }
 
 #################################################
 
+# Create directory to store lock files
+mkdir -p /tmp/sge-gpu
+find /tmp/sge-gpu/ -type d -exec rmdir {} \;
+mkdir -p /tmp/dummy-sge-spool-dir
+find /tmp/dummy-sge-spool-dir/ -type f -exec rm {} \;
+
+# Create dummy Sun Grid Engine job spool directory
+export $SGE_JOB_SPOOL_DIR=/tmp/dummy-sge-spool-dir 
+mkdir -p $SGE_JOB_SPOOL_DIR
+truncate --size=0 $SGE_JOB_SPOOL_DIR/environment
+
 echo "START ...."
 export JOB_ID=$1 # num gpus
-export node_number=1 # user defined
 
 deviceId_func
 check_locks_func
 
 echo "executing Prolog ..................."
 echo "source ./prolog.sh"
-. prolog.sh
+bash prolog.sh
 
 # setting NVIDIA sample path to check the number of visible devices, make sure to compile/build the deviceQuery before hand
 ~/NVIDIA_CUDA-8.0_Samples/1_Utilities/deviceQuery/deviceQuery  -noprompt | egrep "^Device"
 check_locks_func
 
 echo "executing Epilog ..................."
-./epilog.sh
-
+bash ./epilog.sh
 
 check_locks_func
 echo "DONE"
- 

--- a/testQstat.sh
+++ b/testQstat.sh
@@ -5,7 +5,7 @@
 export PATH=$PATH:. 
 
 NGPU=$(qstat -j $1 | \
-        sed -n "s/hard resource_list:.*gpu=\([[:digit:]]\+\).*/\1/p")
+       sed -n "s/hard resource_list:.*gpu=\([[:digit:]]\+\).*/\1/p")
 
 echo $NGPU
 


### PR DESCRIPTION
- [x]  - `CUDA_VISIBLE_DEVICES` environment variable now set in environment of `qsh/qsub` sessions (issue #4) (tested on [ShARC](http://docs.hpc.shef.ac.uk/en/latest/sharc/)
- [x]  - Lock directories cleared when `qsh`/`qsub` session ends (issue #3)
- [x]  - Note which versions of SGE used for testing (issue #1)
- [x]  - Ensure parent dir of locks defined using env var as need to share between prolog and epilog scripts. 
- [x]  - More extensive documentation
- [x] Re-run tests in this repo