### PR TITLE
Add job file and program to test if locks cleared if job fails/killed

### DIFF
--- a/test_sge_gpu_job_fail.c
+++ b/test_sge_gpu_job_fail.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/* Allocate a user-specified amount of memory (in MiB) 
+ * after sleeping for 60s */
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("Usage: %s <MB-to-allocate>\n", argv[0]);
+        return 1;
+    }
+
+    int *p;
+    int mb_to_alloc = atoi(argv[1]);
+    sleep(60);
+    
+    printf("Trying to allocate %d MB of memory...", mb_to_alloc);
+    p = calloc(mb_to_alloc, 1024 * 1024);
+
+    if (! p) {
+        printf("failed!\n");
+        return 1;
+    } else {
+        printf("succeeded!\n");
+        return 1;
+    }
+}

--- a/test_sge_gpu_job_fail.sge
+++ b/test_sge_gpu_job_fail.sge
@@ -1,0 +1,18 @@
+#!/bin/bash
+#$ -M user@shef.ac.uk
+#$ -m bea
+#$ -l h_rt=00:02:00
+#$ -l rmem=100M
+#$ -l gpu=1
+
+# Test if GPU locks are cleared if a job fails.
+#
+# Here we run a C program that first sleeps for 60s then tries to allocate
+# (using calloc) more memory than the scheduler has allocated to this session.
+#
+# The lock should be created by the prolog script and and visible for 60s then
+# should be cleared by the epilog script.
+#
+# This test is designed to be run on Grid Engine, configured as per README.md
+#
+./test_sge_gpu_job_fail 10000


### PR DESCRIPTION
See issue #11.

Ran this job script on the ShARC cluster and 
1. locks were created by the prolog script
1. locks remained whilst job running within resource quota limits
1. job killed when tried to use more memory than allocated by the scheduler
1. locks removed by epilog script.
