### PR TITLE
Switch from using nvidia-smi to querying /proc/driver/nvidia/gpus for GPU count

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ At the University of Sheffield we use these SoGE [queue **prolog** and **epilog*
 1. Just before the job is started on a node the queue's custom **prolog** program runs **on that node**.  This:
     1. Queries the scheduler to determine the number of GPUs requested (then exits if that is <=0)
     1. Scales this number by the number of slots requested if using a [SMP](https://en.wikipedia.org/wiki/Symmetric_multiprocessing) parallel environment called `smp`.
-    1. Uses the `nvidia-smi` utility to discover the indexes of *all* GPUs on the node.
-    1. For all indexes (shuffled) initialise a counter to 0 then: 
+    1. Identifies the number of GPUs, N, by counting the subdirectories of `/proc/driver/nvidia/gpus/`.
+    1. Generates a list of GPU indexes (0..N-1) then shuffle the list.
+    1. Initialise a counter to 0 then for all indexes in that list: 
         1. Try to create a lock by using `mkdir` to create a directory containing the GPU index (`mkdir` is one of the operations that [UNIX/POSIX can do atomically](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html)).
         1. If this suceeds append the index to a list and increment the counter.
         1. If the counter exceeds the number of GPUs requested then break out of the loop early.

--- a/prolog.sh
+++ b/prolog.sh
@@ -28,10 +28,9 @@ fi
 SGE_GPU=""
 # Counter for free devices that we have obtained a lock on
 i=0
-# Get a list of all device IDS which will be space seperated
-#   NB 'nvidia-smi -L' returns lines like
-#   GPU 0: Tesla P100-SXM2-16GB (UUID: GPU-e0fd54a5-16ce-5f57-b5c4-0ecebdd5a450)
-device_ids=$(nvidia-smi -L | cut -f1 -d":" | cut -f2 -d" " | xargs shuf -e)
+# Get a list of all device IDS 
+# (don't use nvidia-smi as it is slow)
+device_ids=$(seq 0 $(( $(ls /proc/driver/nvidia/gpus/ | wc -l) -1 )) | shuf)
 
 # Loop through the device IDs and check to see if a lock can be obtained for the device
 for device_id in $device_ids; do


### PR DESCRIPTION
`nvidia-smi -L` is slow (~5s) and causes `qrshx` to time-out when trying to start an interactive session.  

@mozhgan-kch, @twinkarma, @mondus: Can you see any issues with this approach?  

Also, will we see GPUs listed under `/proc/driver/nvidia-uvm/gpus/` instead of / as well as `/proc/driver/nvidia/gpus/` in future?

